### PR TITLE
feat(dist): remote install script and CI release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: sudo apt-get install -y shellcheck
+      - run: bun install
+      - run: scripts/ci/validate.sh
+
+  build:
+    needs: test
+    strategy:
+      matrix:
+        include:
+          - target: bun-linux-x64
+            runner: ubuntu-latest
+          - target: bun-linux-arm64
+            runner: ubuntu-latest
+          - target: bun-darwin-x64
+            runner: macos-latest
+          - target: bun-darwin-arm64
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: scripts/ci/build.sh "$TARGET"
+        env:
+          TARGET: ${{ matrix.target }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wtf-server-${{ matrix.target }}
+          path: dist/wtf-server-*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - run: scripts/ci/release.sh "$TAG"
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}

--- a/classifier/worker.ts
+++ b/classifier/worker.ts
@@ -135,7 +135,7 @@ async function classifyViaBedrock(
 async function classifyViaCli(
   prompt: string
 ): Promise<ClassifierResult | null> {
-  const proc = Bun.spawn(["claude", "--model", "haiku", "--bare", "--print", "-p", prompt], {
+  const proc = Bun.spawn(["claude", "--model", "haiku", "--bare", "--print", "--no-session-persistence", "-p", prompt], {
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,10 @@ import { handleNow } from "./tools/now";
 import { handleFreshell } from "./tools/freshell";
 import { handleHappened } from "./tools/happened";
 import { handleImout } from "./tools/imout";
-import { startQueueIngestion } from "./queue";
+import { writeFileSync, readFileSync, unlinkSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { execSync } from "node:child_process";
+import { startQueueIngestion, processQueue } from "./queue";
 import { startClassifier } from "./classifier/worker";
 
 if (process.argv.includes("--help")) {
@@ -141,6 +144,74 @@ const TOOLS: Array<{
   },
 ];
 
+// --- Background service lifecycle --------------------------------------------
+
+const queuePath = `${process.cwd()}/.wtf/hook-queue.jsonl`;
+let queueTimer: NodeJS.Timer | null = null;
+let classifierHandle: { stop: () => void } | null = null;
+let sessionMarker: string | null = null;
+
+/** Resolve the project root, matching the agent identity hash convention. */
+function resolveProjectRoot(): string {
+  try {
+    return execSync("git rev-parse --show-toplevel", { encoding: "utf-8" }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+/** Resolve the session marker path from the agent identity file. */
+function resolveSessionMarker(): string | null {
+  const dirHash = createHash("md5").update(resolveProjectRoot()).digest("hex");
+  const agentFile = `/tmp/claude-agent-${dirHash}.json`;
+  if (!existsSync(agentFile)) return null;
+  try {
+    const identity = JSON.parse(readFileSync(agentFile, "utf-8"));
+    if (identity.dev_name) return `/tmp/wtf-recording-${identity.dev_name}`;
+  } catch {}
+  return null;
+}
+
+/** Start queue ingestion and classifier if not already running. */
+function ensureBackgroundServices(): void {
+  if (queueTimer === null) {
+    queueTimer = startQueueIngestion(queuePath);
+  }
+  if (classifierHandle === null) {
+    classifierHandle = startClassifier();
+  }
+  if (sessionMarker === null) {
+    sessionMarker = resolveSessionMarker();
+  }
+  if (sessionMarker) {
+    try { writeFileSync(sessionMarker, String(process.pid)); } catch {}
+  }
+}
+
+/** Flush the queue once, then stop ingestion and classifier. */
+function stopBackgroundServices(): void {
+  processQueue(queuePath);
+
+  if (queueTimer !== null) {
+    clearInterval(queueTimer);
+    queueTimer = null;
+  }
+  if (classifierHandle !== null) {
+    classifierHandle.stop();
+    classifierHandle = null;
+  }
+  if (sessionMarker) {
+    try { unlinkSync(sessionMarker); } catch {}
+  }
+}
+
+// Clean up marker if the server process exits.
+process.on("exit", () => {
+  if (sessionMarker) {
+    try { unlinkSync(sessionMarker); } catch {}
+  }
+});
+
 // --- Handlers ----------------------------------------------------------------
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
@@ -151,19 +222,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   if (name === "wtf_now") {
+    ensureBackgroundServices();
     return handleNow(args as unknown as Parameters<typeof handleNow>[0]);
   }
 
   if (name === "wtf_freshell") {
+    ensureBackgroundServices();
     return handleFreshell(args as unknown as Parameters<typeof handleFreshell>[0]);
   }
 
   if (name === "wtf_happened") {
+    ensureBackgroundServices();
     return handleHappened(args as unknown as Parameters<typeof handleHappened>[0]);
   }
 
   if (name === "wtf_imout") {
     const result = handleImout();
+    stopBackgroundServices();
     return {
       content: [{ type: "text", text: JSON.stringify(result) }],
     };
@@ -180,9 +255,5 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 const transport = new StdioServerTransport();
 await server.connect(transport);
 
-// Start queue ingestion for PostToolUse hook entries.
-const queuePath = `${process.cwd()}/.wtf/hook-queue.jsonl`;
-startQueueIngestion(queuePath);
-
-// Start background classifier for unclassified entries.
-startClassifier();
+// Background services (queue ingestion + classifier) start on first tool call,
+// not at boot. See ensureBackgroundServices() above.

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build a standalone binary for a given bun target.
+# Usage: build.sh <bun-target>
+# Example: build.sh bun-linux-x64
+
+TARGET="${1:?Usage: build.sh <bun-target>}"
+SUFFIX="${TARGET#bun-}"
+
+mkdir -p dist
+bun build --compile --target="$TARGET" index.ts --outfile "dist/wtf-server-${SUFFIX}"
+echo "Built dist/wtf-server-${SUFFIX}"

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a GitHub Release and attach all artifacts.
+# Usage: release.sh <tag>
+# Called by the release workflow after binaries are built.
+
+TAG="${1:?Usage: release.sh <tag>}"
+
+echo "=== Creating release ${TAG} ==="
+
+# Collect binaries from the download-artifact step.
+mkdir -p release-assets
+find artifacts -type f -name 'wtf-server-*' -exec cp {} release-assets/ \;
+find release-assets -type f -name 'wtf-server-*' -exec chmod +x {} \;
+
+# Copy skills and hook into release assets.
+cp scripts/hooks/wtf-post-tool-use.sh release-assets/
+cp scripts/install-remote.sh release-assets/
+for skill in wtf wtf-now wtf-happened wtf-imout; do
+    cp "skills/${skill}/SKILL.md" "release-assets/${skill}-SKILL.md"
+done
+
+# Create the release with auto-generated notes.
+gh release create "$TAG" release-assets/* \
+    --title "$TAG" \
+    --generate-notes
+
+echo "=== Release ${TAG} created ==="

--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# WTF (Why That Failed) — Remote Installer
+#
+# Install mcp-server-wtf from GitHub Releases without cloning the repo.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Wave-Engineering/mcp-server-wtf/main/scripts/install-remote.sh | bash
+#   curl ... | bash -s -- --uninstall
+#   curl ... | bash -s -- --check
+#   curl ... | bash -s -- --version v1.0.0
+
+REPO="Wave-Engineering/mcp-server-wtf"
+BASE_URL="https://github.com/${REPO}/releases"
+
+INSTALL_DIR="${WTF_INSTALL_DIR:-$HOME/.local/bin}"
+DATA_DIR="$HOME/.local/share/wtf-server"
+SKILLS_DIR="$HOME/.claude/skills"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+HOOK_PATH="$DATA_DIR/hooks/wtf-post-tool-use.sh"
+
+MCP_SERVER_NAME="wtf-server"
+VERSION=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+info()  { printf '  \033[1;34m→\033[0m %s\n' "$*"; }
+ok()    { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
+warn()  { printf '  \033[1;33m!\033[0m %s\n' "$*"; }
+fail()  { printf '  \033[1;31m✗\033[0m %s\n' "$*"; }
+die()   { fail "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+detect_platform() {
+    local os arch
+
+    case "$(uname -s)" in
+        Linux)  os="linux" ;;
+        Darwin) os="darwin" ;;
+        *)      die "Unsupported OS: $(uname -s)" ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64)         arch="x64" ;;
+        aarch64|arm64)  arch="arm64" ;;
+        *)              die "Unsupported architecture: $(uname -m)" ;;
+    esac
+
+    PLATFORM_OS="$os"
+    PLATFORM_ARCH="$arch"
+    BINARY_NAME="wtf-server-${os}-${arch}"
+}
+
+# ---------------------------------------------------------------------------
+# Download helper (curl or wget)
+# ---------------------------------------------------------------------------
+
+fetch() {
+    local url="$1" dest="$2"
+    if command -v curl &>/dev/null; then
+        curl -fsSL "$url" -o "$dest"
+    elif command -v wget &>/dev/null; then
+        wget -q "$url" -O "$dest"
+    else
+        die "Neither curl nor wget found"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+
+check_prereqs() {
+    local missing=0
+    for cmd in claude jq; do
+        if command -v "$cmd" &>/dev/null; then
+            ok "$cmd available"
+        else
+            fail "$cmd not found"
+            missing=1
+        fi
+    done
+    if ! command -v curl &>/dev/null && ! command -v wget &>/dev/null; then
+        fail "Neither curl nor wget found"
+        missing=1
+    else
+        ok "$(command -v curl &>/dev/null && echo curl || echo wget) available"
+    fi
+    if [[ $missing -ne 0 ]]; then
+        die "Install missing prerequisites and try again."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Resolve download URL
+# ---------------------------------------------------------------------------
+
+resolve_url() {
+    local file="$1"
+    if [[ -n "$VERSION" ]]; then
+        echo "${BASE_URL}/download/${VERSION}/${file}"
+    else
+        echo "${BASE_URL}/latest/download/${file}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+
+do_install() {
+    echo ""
+    echo "WTF (Why That Failed) — Remote Installer"
+    echo "=========================================="
+    echo ""
+
+    echo "Checking prerequisites..."
+    check_prereqs
+    echo ""
+
+    detect_platform
+    info "Platform: ${PLATFORM_OS}-${PLATFORM_ARCH}"
+    echo ""
+
+    # Download binary
+    info "Downloading ${BINARY_NAME}..."
+    mkdir -p "$INSTALL_DIR"
+    fetch "$(resolve_url "$BINARY_NAME")" "${INSTALL_DIR}/wtf-server"
+    chmod +x "${INSTALL_DIR}/wtf-server"
+    ok "Binary installed to ${INSTALL_DIR}/wtf-server"
+    echo ""
+
+    # Download hook script
+    info "Downloading hook script..."
+    mkdir -p "$DATA_DIR/hooks"
+    fetch "$(resolve_url "wtf-post-tool-use.sh")" "$HOOK_PATH"
+    chmod +x "$HOOK_PATH"
+    ok "Hook installed to $HOOK_PATH"
+    echo ""
+
+    # Download skills
+    info "Installing skills..."
+    for skill in wtf wtf-now wtf-happened wtf-imout; do
+        mkdir -p "$SKILLS_DIR/$skill"
+        fetch "$(resolve_url "${skill}-SKILL.md")" "$SKILLS_DIR/$skill/SKILL.md"
+        ok "Installed /$skill"
+    done
+    echo ""
+
+    # Register MCP server
+    info "Registering MCP server: $MCP_SERVER_NAME"
+    claude mcp add --scope user --transport stdio "$MCP_SERVER_NAME" \
+        -- "${INSTALL_DIR}/wtf-server"
+    ok "MCP server registered"
+    echo ""
+
+    # Configure PostToolUse hook
+    configure_hook
+    echo ""
+
+    # Verify install dir is on PATH
+    if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+        warn "${INSTALL_DIR} is not on your PATH"
+        info "Add it: export PATH=\"${INSTALL_DIR}:\$PATH\""
+    fi
+
+    echo ""
+    echo "Installation Summary"
+    echo "--------------------"
+    ok "Binary: ${INSTALL_DIR}/wtf-server"
+    ok "Skills: ${SKILLS_DIR}/wtf/, wtf-now/, wtf-happened/, wtf-imout/"
+    ok "Hook: PostToolUse → $HOOK_PATH"
+    ok "Data dir: .wtf/ (created on first use, per project)"
+    echo ""
+    echo "Start a troubleshooting session:  /wtf"
+    echo "Record an observation:            /wtf now <text>"
+    echo "Get the timeline:                 /wtf happened"
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Hook configuration (matches install.sh logic)
+# ---------------------------------------------------------------------------
+
+configure_hook() {
+    info "Configuring PostToolUse hook..."
+
+    mkdir -p "$(dirname "$SETTINGS_FILE")"
+    if [[ ! -f "$SETTINGS_FILE" ]]; then
+        echo '{}' > "$SETTINGS_FILE"
+    fi
+
+    local hook_entry
+    hook_entry=$(jq -n --arg cmd "$HOOK_PATH" \
+        '{"matcher":"","hooks":[{"type":"command","command":$cmd}]}')
+
+    local updated
+    updated=$(jq --argjson entry "$hook_entry" '
+        .hooks //= {} |
+        .hooks.PostToolUse //= [] |
+        if (.hooks.PostToolUse | map(.hooks // [] | map(select(.command == $entry.hooks[0].command))) | flatten | length) > 0
+        then .
+        else .hooks.PostToolUse += [$entry]
+        end
+    ' "$SETTINGS_FILE")
+
+    printf '%s\n' "$updated" > "$SETTINGS_FILE"
+    ok "PostToolUse hook configured"
+}
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
+
+do_uninstall() {
+    echo ""
+    echo "WTF — Remote Uninstaller"
+    echo "========================"
+    echo ""
+
+    # Remove binary
+    if [[ -f "${INSTALL_DIR}/wtf-server" ]]; then
+        rm "${INSTALL_DIR}/wtf-server"
+        ok "Removed binary"
+    else
+        warn "Binary not found at ${INSTALL_DIR}/wtf-server"
+    fi
+
+    # Remove MCP registration
+    info "Removing MCP server registration..."
+    if claude mcp remove "$MCP_SERVER_NAME" 2>/dev/null; then
+        ok "MCP server removed"
+    else
+        warn "MCP server was not registered"
+    fi
+
+    # Remove skills
+    info "Removing skills..."
+    for skill in wtf wtf-now wtf-happened wtf-imout; do
+        if [[ -f "$SKILLS_DIR/$skill/SKILL.md" ]]; then
+            rm "$SKILLS_DIR/$skill/SKILL.md"
+            rmdir "$SKILLS_DIR/$skill" 2>/dev/null || true
+            ok "Removed /$skill"
+        else
+            warn "Skill /$skill not found"
+        fi
+    done
+
+    # Remove hook from settings
+    info "Removing PostToolUse hook..."
+    if [[ -f "$SETTINGS_FILE" ]]; then
+        local updated
+        updated=$(jq --arg cmd "$HOOK_PATH" '
+            if .hooks.PostToolUse then
+                .hooks.PostToolUse |= map(
+                    if (.hooks // [] | map(select(.command == $cmd)) | length) > 0
+                    then .hooks |= map(select(.command != $cmd))
+                    else .
+                    end
+                ) |
+                .hooks.PostToolUse |= map(select((.hooks // []) | length > 0)) |
+                if (.hooks.PostToolUse | length) == 0 then del(.hooks.PostToolUse) else . end |
+                if (.hooks | length) == 0 then del(.hooks) else . end
+            else .
+            end
+        ' "$SETTINGS_FILE")
+        printf '%s\n' "$updated" > "$SETTINGS_FILE"
+        ok "Hook removed"
+    fi
+
+    # Remove data dir
+    if [[ -d "$DATA_DIR" ]]; then
+        rm -rf "$DATA_DIR"
+        ok "Removed $DATA_DIR"
+    fi
+
+    echo ""
+    ok "Uninstall complete"
+    info "Per-project .wtf/ directories were not removed (contain incident history)."
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Check
+# ---------------------------------------------------------------------------
+
+do_check() {
+    echo ""
+    echo "WTF — Installation Check"
+    echo "========================"
+    echo ""
+    local issues=0
+
+    # Prerequisites
+    for cmd in claude jq; do
+        if command -v "$cmd" &>/dev/null; then
+            ok "$cmd available"
+        else
+            fail "$cmd not found"
+            issues=$((issues + 1))
+        fi
+    done
+
+    # Binary
+    if [[ -x "${INSTALL_DIR}/wtf-server" ]]; then
+        ok "Binary at ${INSTALL_DIR}/wtf-server"
+    else
+        fail "Binary not found at ${INSTALL_DIR}/wtf-server"
+        issues=$((issues + 1))
+    fi
+
+    # MCP registration
+    if claude mcp list 2>/dev/null | grep -q "$MCP_SERVER_NAME"; then
+        ok "MCP server registered"
+    else
+        fail "MCP server not registered"
+        issues=$((issues + 1))
+    fi
+
+    # Skills
+    for skill in wtf wtf-now wtf-happened wtf-imout; do
+        if [[ -f "$SKILLS_DIR/$skill/SKILL.md" ]]; then
+            ok "Skill /$skill installed"
+        else
+            fail "Skill /$skill missing"
+            issues=$((issues + 1))
+        fi
+    done
+
+    # Hook
+    if [[ -f "$SETTINGS_FILE" ]] && \
+       jq -e --arg cmd "$HOOK_PATH" \
+          '.hooks.PostToolUse // [] | map(.hooks // [] | map(select(.command == $cmd))) | flatten | length > 0' \
+          "$SETTINGS_FILE" &>/dev/null; then
+        ok "PostToolUse hook configured"
+    else
+        fail "PostToolUse hook not found"
+        issues=$((issues + 1))
+    fi
+
+    echo ""
+    if [[ $issues -eq 0 ]]; then
+        ok "All checks passed"
+    else
+        fail "$issues issue(s) found"
+        info "Run the installer to fix: curl -fsSL ...install-remote.sh | bash"
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --uninstall) ACTION="uninstall"; shift ;;
+        --check)     ACTION="check"; shift ;;
+        --version)   VERSION="${2:?--version requires a tag}"; shift 2 ;;
+        *)           die "Unknown flag: $1 (use --uninstall, --check, or --version <tag>)" ;;
+    esac
+done
+
+case "${ACTION:-install}" in
+    install)   do_install ;;
+    uninstall) do_uninstall ;;
+    check)     do_check ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# WTF (Why That Failed) — installer
+# WTF (Why That Failed) — Local Development Installer
 #
-# Idempotent installer for the WTF flight recorder system. Registers the
-# MCP server, installs skills, and configures the PostToolUse hook.
+# This installer is for LOCAL DEVELOPMENT of the WTF server. It registers
+# the MCP server pointing to this cloned repo, which is what you want when
+# working on the code.
+#
+# For end-user installation (no clone required), use the remote installer:
+#   curl -fsSL https://raw.githubusercontent.com/Wave-Engineering/mcp-server-wtf/main/scripts/install-remote.sh | bash
 #
 # Usage:
 #   ./scripts/install.sh              Install everything


### PR DESCRIPTION
## Summary

Add a `curl | bash` install path so users don't need to clone the repo. CI compiles standalone binaries via `bun build --compile` for 4 platform targets and attaches them to GitHub Releases alongside skills and hook script.

Also includes two operational fixes:
- CLI classifier fallback now passes `--no-session-persistence` to prevent session journal destruction
- Background services (queue ingestion + classifier) start lazily on first tool call instead of at boot, stop on `wtf_imout`

## Changes

- **`.github/workflows/release.yml`** — Release pipeline: test → build matrix (linux-x64, linux-arm64, darwin-x64, darwin-arm64) → GitHub Release
- **`scripts/ci/build.sh`** — Compile script wrapping `bun build --compile`
- **`scripts/ci/release.sh`** — Assembles release assets and creates GitHub Release via `gh`
- **`scripts/install-remote.sh`** — Remote installer with platform detection, `--uninstall`, `--check`, `--version` flags
- **`scripts/install.sh`** — Updated header pointing to remote installer for non-dev use
- **`classifier/worker.ts`** — Added `--no-session-persistence` to CLI fallback
- **`index.ts`** — Lazy background service lifecycle + session recording marker for statusline

## Linked Issues

Closes #1

## Test Plan

- `scripts/ci/validate.sh` passes (lint, shellcheck 6 files, 86/86 tests)
- `bun build --compile` produces a working 97MB binary that serves all 4 MCP tools
- `install-remote.sh --check` correctly reports installation status
- Code reviewer ran: 4 high-risk findings fixed (CI injection sanitization, session marker hash, chmod glob safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)