### PR TITLE
fix: installer ETXTBSY on running binary

### DIFF
--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -63,13 +63,15 @@ detect_platform() {
 
 fetch() {
     local url="$1" dest="$2"
+    local tmp="${dest}.tmp.$$"
     if command -v curl &>/dev/null; then
-        curl -fsSL "$url" -o "$dest"
+        curl -fsSL "$url" -o "$tmp"
     elif command -v wget &>/dev/null; then
-        wget -q "$url" -O "$dest"
+        wget -q "$url" -O "$tmp"
     else
         die "Neither curl nor wget found"
     fi
+    mv -f "$tmp" "$dest"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `curl: (23) Failure writing output to destination` when running the remote installer while the WTF server is active. On Linux, overwriting a running executable returns `ETXTBSY`. The fix writes to a temp file then `mv -f` into place — `rename(2)` works on busy executables.

## Changes

- **`scripts/install-remote.sh`** — `fetch()` now writes to `${dest}.tmp.$$` then `mv -f` to the final path

## Linked Issues

Closes #6

## Test Plan

- `scripts/ci/validate.sh` — shellcheck clean, 86/86 tests pass
- Verified `mv -f` semantics: running processes keep the old inode, new binary takes the path

🤖 Generated with [Claude Code](https://claude.com/claude-code)