### PR TITLE
feat: auto-resume recording on boot

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -242,10 +242,9 @@ function stopBackgroundServices(): void {
   removeIndicator();
 }
 
-// Clean up indicator if the server process exits.
-process.on("exit", () => {
-  removeIndicator();
-});
+// No process.on("exit") cleanup — a surviving indicator signals that the
+// previous session was mid-incident. The next MCP server boot detects it
+// and auto-resumes recording. Only wtf_imout removes the indicator.
 
 // --- Handlers ----------------------------------------------------------------
 
@@ -291,4 +290,12 @@ const transport = new StdioServerTransport();
 await server.connect(transport);
 
 // Background services (queue ingestion + classifier) start on first tool call,
-// not at boot. See ensureBackgroundServices() above.
+// not at boot — UNLESS a previous session left the indicator in the statusline
+// file, which means we were mid-incident when we got killed. Resume recording.
+statuslineFile = resolveStatuslineFile();
+if (statuslineFile) {
+  const existing = readIndicators(statuslineFile);
+  if (existing.includes(WTF_INDICATOR)) {
+    ensureBackgroundServices();
+  }
+}


### PR DESCRIPTION
## Summary

When the MCP server boots and finds `☠️ WTF ●` already in the statusline file, auto-start background services to resume recording. Removes the `process.on("exit")` cleanup so the indicator survives unclean shutdown — turning an accidental stale-state bug into a crash-recovery feature.

## Changes

- **`index.ts`** — On boot, check statusline file for existing indicator → auto-start if present
- **`index.ts`** — Remove `process.on("exit")` handler; only `/wtf imout` clears the indicator

## Linked Issues

Closes #9

## Test Plan

- `scripts/ci/validate.sh` — 86/86 tests pass, lint clean, shellcheck clean
- Manual: quit session mid-recording, restart → recording auto-resumes
- Manual: `/wtf imout` → indicator removed, next boot stays idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)