### PR TITLE
fix(install): make MCP registration idempotent

### DIFF
--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -155,8 +155,9 @@ do_install() {
     done
     echo ""
 
-    # Register MCP server
+    # Register MCP server (remove first for idempotency)
     info "Registering MCP server: $MCP_SERVER_NAME"
+    claude mcp remove "$MCP_SERVER_NAME" 2>/dev/null || true
     claude mcp add --scope user --transport stdio "$MCP_SERVER_NAME" \
         -- "${INSTALL_DIR}/wtf-server"
     ok "MCP server registered"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,9 +68,8 @@ install_deps() {
 }
 
 register_mcp() {
-    # claude mcp add is idempotent — it overwrites an existing entry with the
-    # same name, so running twice is safe.
     info "Registering MCP server: $MCP_SERVER_NAME"
+    claude mcp remove "$MCP_SERVER_NAME" 2>/dev/null || true
     claude mcp add --scope user --transport stdio "$MCP_SERVER_NAME" \
         -- bun "$MCP_DIR/index.ts"
     ok "MCP server registered (scope: user)"


### PR DESCRIPTION
## Summary

Remove existing MCP registration before adding to avoid `already exists` failures on re-install. Found during first real use of cc-workflow's bundle installer — re-running the installer failed because `claude mcp add` errors when the server is already registered.

## Changes

- `scripts/install-remote.sh` — add `claude mcp remove` before `claude mcp add`
- `scripts/install.sh` — same fix, remove stale "idempotent" comment that was wrong

## Test Plan

- Verified on mother: first install succeeds, re-install now succeeds instead of erroring

Generated with [Claude Code](https://claude.com/claude-code)