### PR TITLE
fix(release): make release.sh idempotent for pre-existing releases

### DIFF
--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -21,9 +21,14 @@ for skill in wtf wtf-now wtf-happened wtf-imout; do
     cp "skills/${skill}/SKILL.md" "release-assets/${skill}-SKILL.md"
 done
 
-# Create the release with auto-generated notes.
-gh release create "$TAG" release-assets/* \
-    --title "$TAG" \
-    --generate-notes
+# Create the release (or upload to an existing one).
+if gh release view "$TAG" &>/dev/null; then
+    echo "Release ${TAG} already exists — uploading assets"
+    gh release upload "$TAG" release-assets/* --clobber
+else
+    gh release create "$TAG" release-assets/* \
+        --title "$TAG" \
+        --generate-notes
+fi
 
 echo "=== Release ${TAG} created ==="


### PR DESCRIPTION
## Summary
- Make `release.sh` check if a GitHub release already exists before calling `gh release create`
- If the release exists, upload assets with `gh release upload --clobber` instead of failing
- Fixes the v1.3.1 empty release that caused remote installer 404s

Closes #14

## Test plan
- [ ] Verify `scripts/ci/validate.sh` passes (lint, shellcheck, 86 tests)
- [ ] Re-run release workflow for v1.3.1 after merge to confirm assets upload correctly
- [ ] Test remote installer after assets are uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)