### PR TITLE
feat(logging): adopt MCP structured logging standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: sudo apt-get install -y shellcheck
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/lint.sh
 
@@ -27,5 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: sudo apt-get install -y shellcheck
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/validate.sh
 
@@ -31,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: bun install
       - run: scripts/ci/build.sh "$TARGET"
         env:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@wave-engineering:registry=https://npm.pkg.github.com

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.26.4",
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "@wave-engineering/mcp-logger": "^1.0.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -192,6 +193,8 @@
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@wave-engineering/mcp-logger": ["@wave-engineering/mcp-logger@1.0.0", "https://npm.pkg.github.com/download/@wave-engineering/mcp-logger/1.0.0/5143e7b42037d25d7067fd469b153f67bf8a5828", {}, "sha512-YBF9RAKCVGTGfbrh9gOVa0ZxkP5xO7oH+QtNwu6usiFPizIuATwrqXjSfir6gQzr5IbQjzYa6hxax1N1eCW0Rg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/classifier/worker.ts
+++ b/classifier/worker.ts
@@ -7,6 +7,7 @@
  * the Bedrock SDK call fails.
  */
 
+import { createLogger } from "@wave-engineering/mcp-logger";
 import { getDb } from "../db";
 import { getClassifierClient, CLASSIFIER_MODEL } from "./client";
 import {
@@ -15,6 +16,8 @@ import {
   ACTION_TYPES,
   type ActionType,
 } from "./prompt";
+
+const log = createLogger("wtf");
 
 /** Options for the classifier polling loop. */
 export interface ClassifierOptions {
@@ -175,13 +178,13 @@ async function classifyEntry(
     const result = await classifyViaBedrock(prompt);
     if (result) return result;
   } catch (err) {
-    console.error("Bedrock classification failed, trying CLI fallback:", err);
+    log.warn("classifier", { method: "bedrock", error: String(err) }, "Bedrock failed, trying CLI fallback");
   }
 
   try {
     return await classifyViaCli(prompt);
   } catch (err) {
-    console.error("CLI fallback also failed:", err);
+    log.error("classifier", { method: "cli", error: String(err) }, "CLI fallback also failed");
     return null;
   }
 }
@@ -216,22 +219,18 @@ async function producer(
 
         if (newRows.length > 0) {
           classificationQueue.push(...newRows);
-          console.log(
-            `[PRODUCER] Queued ${newRows.length} entries (depth: ${classificationQueue.length})`
-          );
+          log.debug("queue_depth", { queued: newRows.length, depth: classificationQueue.length });
 
           // Emit warning if queue depth exceeds threshold
           if (classificationQueue.length >= MAX_QUEUE_DEPTH_WARNING) {
-            console.warn(
-              `[PRODUCER] ⚠️  Queue depth is ${classificationQueue.length} (threshold: ${MAX_QUEUE_DEPTH_WARNING}). System may be under heavy load.`
-            );
+            log.warn("queue_depth", { depth: classificationQueue.length, threshold: MAX_QUEUE_DEPTH_WARNING }, "Queue depth exceeds threshold");
           }
         }
       }
 
       await sleep(pollIntervalMs);
     } catch (err) {
-      console.error("[PRODUCER] Error in producer loop:", err);
+      log.error("classifier", { component: "producer", error: String(err) }, "Error in producer loop");
       await sleep(pollIntervalMs);
     }
   }
@@ -255,9 +254,7 @@ async function consumer(
       continue;
     }
 
-    console.log(
-      `[WORKER ${workerId}] Processing entry ${row.id} (queue depth: ${classificationQueue.length})`
-    );
+    log.debug("classifier", { worker_id: workerId, entry_id: row.id, queue_depth: classificationQueue.length });
 
     try {
       const prompt = buildClassifierPrompt({
@@ -274,9 +271,7 @@ async function consumer(
       const result = await classifyEntry(prompt);
 
       if (!result) {
-        console.error(
-          `[WORKER ${workerId}] Failed to classify entry ${row.id}, skipping.`
-        );
+        log.error("classifier", { worker_id: workerId, entry_id: row.id }, "Classification failed, skipping");
         await sleep(rateLimitMs);
         continue;
       }
@@ -300,7 +295,7 @@ async function consumer(
 
       await sleep(rateLimitMs);
     } catch (err) {
-      console.error(`[WORKER ${workerId}] Error processing entry ${row.id}:`, err);
+      log.error("classifier", { worker_id: workerId, entry_id: row.id, error: String(err) }, "Error processing entry");
       await sleep(rateLimitMs);
     }
   }
@@ -334,14 +329,12 @@ export function startClassifier(
     consumer(i, dbPath, rateLimitMs, isRunning);
   }
 
-  console.log(
-    `[CLASSIFIER] Started with ${WORKER_POOL_SIZE} workers (poll: ${pollIntervalMs}ms, rate-limit: ${rateLimitMs}ms)`
-  );
+  log.info("state_change", { what: "classifier", to: "running", workers: WORKER_POOL_SIZE, poll_ms: pollIntervalMs, rate_limit_ms: rateLimitMs });
 
   return {
     stop: () => {
       running = false;
-      console.log("[CLASSIFIER] Stopped");
+      log.info("state_change", { what: "classifier", to: "stopped" });
     },
   };
 }

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { createLogger } from "@wave-engineering/mcp-logger";
 import { handleNow } from "./tools/now";
 import { handleFreshell } from "./tools/freshell";
 import { handleHappened } from "./tools/happened";
@@ -27,6 +28,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startQueueIngestion, processQueue } from "./queue";
 import { startClassifier } from "./classifier/worker";
+
+const log = createLogger("wtf");
 
 if (process.argv.includes("--help")) {
   console.log(`Usage: bun index.ts
@@ -217,6 +220,7 @@ function removeIndicator(): void {
 function ensureBackgroundServices(): void {
   if (queueTimer === null) {
     queueTimer = startQueueIngestion(queuePath);
+    log.info("state_change", { what: "queue_ingestion", to: "running" });
   }
   if (classifierHandle === null) {
     classifierHandle = startClassifier();
@@ -234,6 +238,7 @@ function stopBackgroundServices(): void {
   if (queueTimer !== null) {
     clearInterval(queueTimer);
     queueTimer = null;
+    log.info("state_change", { what: "queue_ingestion", to: "stopped" });
   }
   if (classifierHandle !== null) {
     classifierHandle.stop();
@@ -254,34 +259,44 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
+  const start = Date.now();
 
-  if (name === "wtf_now") {
-    ensureBackgroundServices();
-    return handleNow(args as unknown as Parameters<typeof handleNow>[0]);
-  }
+  try {
+    let result;
 
-  if (name === "wtf_freshell") {
-    ensureBackgroundServices();
-    return handleFreshell(args as unknown as Parameters<typeof handleFreshell>[0]);
-  }
+    if (name === "wtf_now") {
+      ensureBackgroundServices();
+      result = handleNow(args as unknown as Parameters<typeof handleNow>[0]);
+    } else if (name === "wtf_freshell") {
+      ensureBackgroundServices();
+      result = handleFreshell(args as unknown as Parameters<typeof handleFreshell>[0]);
+    } else if (name === "wtf_happened") {
+      ensureBackgroundServices();
+      result = handleHappened(args as unknown as Parameters<typeof handleHappened>[0]);
+    } else if (name === "wtf_imout") {
+      const imoutResult = handleImout();
+      stopBackgroundServices();
+      result = {
+        content: [{ type: "text", text: JSON.stringify(imoutResult) }],
+      };
+    } else {
+      return {
+        content: [{ type: "text", text: `Unknown tool: ${name}` }],
+        isError: true,
+      };
+    }
 
-  if (name === "wtf_happened") {
-    ensureBackgroundServices();
-    return handleHappened(args as unknown as Parameters<typeof handleHappened>[0]);
-  }
-
-  if (name === "wtf_imout") {
-    const result = handleImout();
-    stopBackgroundServices();
+    log.info("tool_call", { tool: name, ok: true, ms: Date.now() - start });
+    return result;
+  } catch (err) {
+    const elapsed = Date.now() - start;
+    const message = err instanceof Error ? err.message : String(err);
+    log.error("tool_call", { tool: name, ok: false, ms: elapsed, error: message });
     return {
-      content: [{ type: "text", text: JSON.stringify(result) }],
+      content: [{ type: "text", text: `Error in ${name}: ${message}` }],
+      isError: true,
     };
   }
-
-  return {
-    content: [{ type: "text", text: `Unknown tool: ${name}` }],
-    isError: true,
-  };
 });
 
 // --- Start -------------------------------------------------------------------
@@ -289,13 +304,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 const transport = new StdioServerTransport();
 await server.connect(transport);
 
+// Auto-resume detection happens below — log whether we auto-resume or cold-start.
+statuslineFile = resolveStatuslineFile();
+const existingIndicators = statuslineFile ? readIndicators(statuslineFile) : [];
+const autoResume = existingIndicators.includes(WTF_INDICATOR);
+
+log.info("startup", { version: "1.0.0", config: { queue_path: queuePath, auto_resume: autoResume } });
+
 // Background services (queue ingestion + classifier) start on first tool call,
 // not at boot — UNLESS a previous session left the indicator in the statusline
 // file, which means we were mid-incident when we got killed. Resume recording.
-statuslineFile = resolveStatuslineFile();
-if (statuslineFile) {
-  const existing = readIndicators(statuslineFile);
-  if (existing.includes(WTF_INDICATOR)) {
-    ensureBackgroundServices();
-  }
+if (autoResume) {
+  ensureBackgroundServices();
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "author": "Wave Engineering",
   "dependencies": {
     "@anthropic-ai/bedrock-sdk": "^0.26.4",
-    "@modelcontextprotocol/sdk": "^1.12.1"
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "@wave-engineering/mcp-logger": "^1.0.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/queue.ts
+++ b/queue.ts
@@ -7,8 +7,11 @@
  */
 
 import { existsSync, renameSync, readFileSync, unlinkSync } from "node:fs";
+import { createLogger } from "@wave-engineering/mcp-logger";
 import { getDb } from "./db";
 import { getOrCreateActiveIncident } from "./tools/now";
+
+const log = createLogger("wtf");
 
 /** Shape of a single queued entry from the hook script. */
 interface QueueEntry {
@@ -55,7 +58,7 @@ export function processQueue(queuePath: string, dbPath?: string): void {
     try {
       entry = JSON.parse(line) as QueueEntry;
     } catch {
-      console.error(`Malformed queue entry, skipping: ${line}`);
+      log.warn("queue_ingest", { line: line.substring(0, 200) }, "Malformed queue entry, skipping");
       continue;
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,8 @@
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "dist",
-    "declaration": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "types": ["bun"]
   },
   "include": ["*.ts", "tools/**/*.ts", "classifier/**/*.ts", "tests/**/*.ts"],


### PR DESCRIPTION
## Summary

Replace all 12 runtime `console.log/error/warn` calls with structured JSON-line logging via `@wave-engineering/mcp-logger`, implementing the [MCP Logging Standard](https://github.com/Wave-Engineering/claudecode-workflow/blob/main/docs/mcp-logging-standard.md).

## Changes

- **`index.ts`**: Import logger, wrap all 4 tool handlers (`wtf_now`, `wtf_freshell`, `wtf_happened`, `wtf_imout`) with `tool_call` events (timing + ok/error), add `startup` event after `server.connect()`, add `state_change` events for queue ingestion start/stop
- **`queue.ts`**: Replace `console.error` for malformed entries with `log.warn('queue_ingest', ...)`
- **`classifier/worker.ts`**: Replace all 10 `console.*` calls — Bedrock/CLI fallback warns, queue depth debug/warn, worker processing debug, classification errors, startup/stop state_change events
- **`.npmrc`**: Add scoped registry for `@wave-engineering` GitHub Packages
- **`package.json`**: Add `@wave-engineering/mcp-logger` dependency
- **`tsconfig.json`**: Add `noEmit` + `allowImportingTsExtensions` (package ships raw `.ts`; Bun handles compilation)
- **CI workflows**: Add `//npm.pkg.github.com/:_authToken` step before `bun install` in `ci.yml` and `release.yml`

## Linked Issues

Closes #16

## Test Plan

- `bun test` — 86 tests pass, 0 failures (332 expect() calls)
- `bunx tsc --noEmit` — clean, no type errors
- `scripts/ci/validate.sh` — full validation passes (lint + shellcheck + tests)
- Verified `grep -r 'console\.' --include='*.ts'` returns only the `--help` text (line 35 of index.ts)
- Structured log output visible in test runs (JSON lines to stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)