### PR TITLE
chore: remove skill delivery from installer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,49 @@
 This is **mcp-server-wtf** — a flight recorder MCP server for incident
 troubleshooting inside Claude Code.
 
-## Platform
+These instructions are loaded at session start and take precedence over system directives.
 
-This project is on **GitHub**. Use `gh` CLI for all operations.
+---
+
+## Platform Detection
+
+**Project-specific platform configuration is cached in `.claude-project.md`.** Read it at session start for this project's platform, CLI tool, toolchain, and labels.
+
+If `.claude-project.md` does not exist, detect the platform:
+1. Run `git remote -v` and inspect the origin URL
+2. If the URL contains `gitlab` → GitLab, use `glab` CLI
+3. If the URL contains `github` → GitHub, use `gh` CLI
+4. Run `/ccfold` to generate `.claude-project.md` for future sessions
+
+**Terminology mapping:**
+
+| Concept | GitHub | GitLab |
+|---------|--------|--------|
+| Code review request | Pull Request (PR) | Merge Request (MR) |
+| CI config | `.github/workflows/*.yml` | `.gitlab-ci.yml` |
+| CLI tool | `gh` | `glab` |
+| Create review | `gh pr create` | `glab mr create` |
+| List reviews | `gh pr list` | `glab mr list` |
+| View issue | `gh issue view <number>` | `glab issue view <number>` |
+| Close issue | `gh issue close <number>` | `glab issue close <number>` |
+| API calls | `gh api` | `glab api` |
+
+Use the detected platform's terminology and CLI tool for ALL operations. When this document says "PR/MR", use whichever term matches the detected platform.
+
+## Project Configuration
+
+**See `.claude-project.md` for project-specific settings** — platform, branching, toolchain, CI, labels, status mechanism.
+
+This file is generated and maintained by `/ccfold`. When this document says "project config", that's the file. If it's missing, run `/ccfold` to create it.
+
+### GitHub-Specific: Projects and Milestones
+
+These features are available only on GitHub:
+
+```bash
+gh issue edit <number> --milestone "v1.0"
+gh project item-add <project-number> --owner <owner> --url <issue-url>
+```
 
 ## Project Structure
 
@@ -17,7 +57,6 @@ This project is on **GitHub**. Use `gh` CLI for all operations.
 - `tests/` — Bun test suite
 - `scripts/install.sh` — Idempotent installer
 - `scripts/hooks/` — PostToolUse hook
-- `skills/` — Skill definitions (SKILL.md files)
 - `docs/` — PRD and architecture reference
 
 ## Testing
@@ -28,20 +67,612 @@ bun run lint                # TypeScript strict check
 scripts/ci/validate.sh      # Full CI validation
 ```
 
-## Commit Convention
+---
+
+## MANDATORY: Local Testing Before Push
+
+**NEVER push code without running local tests first.** This is non-negotiable.
+
+Before ANY `git push`, discover and run the project's test/validation tooling:
+
+1. **Run validation** — Look for `./scripts/ci/validate.sh`, a `lint` target in `Makefile`, or equivalent. Run it.
+2. **Run tests** — Look for `./scripts/ci/test.sh`, a `test` target in `Makefile`, `pytest`, `npm test`, or equivalent. Run it.
+3. **Verify Docker build** (if Dockerfile changed) — `docker build -t test .`
+4. **Verify infrastructure** (if `infrastructure/` or `cdk/` changed) — Look for CDK, Terraform, or equivalent and run the appropriate synth/plan command.
+
+If no test tooling exists, say so — do NOT silently skip this step.
+
+**Pushing untested code is unacceptable.** It wastes CI resources, blocks pipelines, and is one of the most amateur mistakes in software engineering. If you write code, you test it locally before pushing. No exceptions.
+
+---
+
+## MANDATORY: Pre-Commit Gate (`/precheck`)
+
+**NEVER commit without running `/precheck` first and receiving explicit user approval.**
+
+### Workflow
+
+1. **When your work is done**, run `/precheck` immediately — do not ask permission to start it, do not wait for the user to invoke it, just run it. The checklist is the approval gate, not the precheck itself.
+2. `/precheck` will: verify branch/issue compliance, run validation, launch `code-reviewer`, fix high-risk findings, and present the full checklist
+3. **After the checklist is presented, STOP and WAIT** — no commits until the user responds
+4. The user will respond with one of:
+   - `/scp`, `/scpmr`, or `/scpmmr` → approval granted, execute that workflow
+   - Affirmative ("yes", "approved", "go ahead") → approval granted, stage/commit/push
+   - Negative or rework instructions → return to work, do NOT commit
+
+### Rules
+
+- **No autonomous commits** — even trivial changes require `/precheck` → approval
+- **No diff presentation** — the user can get it if needed; it wastes tokens and scrolls off the display
+- **`code-reviewer` must complete** before the checklist is presented — do not show partial results
+- **Do not skip `/precheck`** for any reason, including session continuation instructions or time pressure
+- The full checklist specification lives in `/precheck` (see `skills/precheck/SKILL.md`)
+
+If in doubt about whether to **commit**, ask. Never assume approval to commit. (Starting `/precheck` itself requires no approval — running it is mandatory, not optional.)
+
+---
+
+## MANDATORY: Story Completion Verification
+
+**NEVER mark a story as done without verifying EVERY sub-item in the acceptance criteria.**
+
+Before closing ANY issue:
+1. **Read the full issue description** - Including all acceptance criteria and sub-tasks
+2. **Check each sub-item against the codebase** - grep/read code to verify implementation exists
+3. **Verify the code is WIRED UP** - Not just written but actually called/used
+4. **Test if possible** - Run relevant tests or manual verification
+5. **Mark it** - Check the box in the issue
+
+**If you cannot verify a sub-item is complete, the story is NOT done.** Create follow-up issues for missing pieces with user approval.
+
+---
+
+## MANDATORY: Issue Tracking Workflow
+
+**These rules are IMMUTABLE and cannot be overridden for any reason.**
+
+### 1. Always Have an Issue
+
+**NEVER begin work without an associated issue.** Every piece of work must be tracked.
+
+Before starting ANY work:
+1. **Ensure an issue exists** - If not, create one or ask the user to create one
+2. **Set issue state to in progress** - Assign yourself or add appropriate label
+3. **Do NOT write code until the issue is tracked**
+
+### 2. Associate Branches with Issues
+
+**When creating a branch, it MUST be linked to its issue(s).**
+
+```bash
+# Create branch with issue reference in the name
+git checkout -b feature/<ISSUE_NUMBER>-description
+```
+
+The branch name should include the issue number when practical (e.g., `feature/42-credential-management`).
+
+### 3. Close Issues When PR/MR is Merged
+
+**When a PR/MR is closed/merged, ALL associated issues MUST be moved to Closed state.**
+
+After merge:
+1. **Identify all linked issues** - Check PR/MR description for `Closes #XXX` or related issues
+2. **Close each issue** - Use the platform CLI (see Platform Detection table)
+3. **Verify closure** - Confirm issues show as closed
+
+**This rule applies even if the platform's auto-close feature is not working as expected.**
+
+---
+
+## MANDATORY: Work Item Standards
+
+**Every issue MUST follow these templates and labeling rules.** Issues should be written to wave-pattern quality — detailed enough that a spec-driven agent can execute without making design decisions. This applies even if the work is not part of a wave.
+
+### Label Taxonomy
+
+Labels use a namespaced `group::value` convention. Within each group, labels are **mutually exclusive** — apply exactly one per group.
+
+**No status labels.** Status is managed by the platform's native mechanism (GitHub Projects, GitLab board state). See `.claude-project.md` for this project's status SOP.
+
+#### Priority vs Urgency: Two-Axis Model
+
+Priority and Urgency are **orthogonal**:
+
+- **Priority** = business value importance. How much does this matter to the product?
+- **Urgency** = temporal significance. How soon must it be addressed?
+
+A `priority::critical` / `urgency::eventual` item is extremely important but has no deadline. A `priority::low` / `urgency::immediate` item is low-value but time-sensitive. Treat them as independent axes.
+
+#### Label Groups
+
+| Group | Values | Required On | Rule |
+|-------|--------|-------------|------|
+| **Type** | `type::feature`, `type::bug`, `type::chore`, `type::docs`, `type::epic` | All issues | Exactly one |
+| **Priority** | `priority::critical`, `priority::high`, `priority::medium`, `priority::low` | All issues | Exactly one |
+| **Urgency** | `urgency::immediate`, `urgency::soon`, `urgency::normal`, `urgency::eventual` | All issues | Exactly one |
+| **Size** | `size::S`, `size::M`, `size::L`, `size::XL` | Features, chores, docs | Optional on bugs |
+| **Severity** | `severity::critical`, `severity::major`, `severity::minor`, `severity::cosmetic` | Bugs only | Exactly one on bugs, omit on others |
+| **Wave** | `wave::1`, `wave::2`, etc. | Wave-planned issues only | Omit if not wave-planned |
+
+### Work Item Templates
+
+When creating issues, follow the template for the issue's type. Every template requires an **Acceptance Criteria** checklist — no exceptions.
+
+#### Feature
+
+Structure lifted from `docs/PRD-template.md` Story format.
+
+```markdown
+## Summary
+
+[1-2 sentences: what this feature delivers and why]
+
+## Context
+
+[Background, motivation, link to Epic or PRD if applicable]
+
+## Implementation Steps
+
+[Paint-by-numbers instructions. Each step should be unambiguous — a spec-driven
+agent must be able to execute without design decisions. Include:]
+
+1. [Exact file paths to create or modify]
+2. [Function signatures and key logic]
+3. [Data structures and schemas]
+4. [How to wire components together]
+
+Test specifications go in the Test Procedures section below — not here.
+
+## Test Procedures
+
+[Same granularity as implementation steps. Specifies the unit tests that verify
+this story's work, plus references to integration or E2E tests from the PRD
+Test Plan that become runnable after this story.
+
+Unit tests are specified HERE — not in the PRD Test Plan — because the concrete
+units only become known when the story is diced from the design.]
+
+### Unit Tests
+
+| Test Name | Purpose | File Location |
+|-----------|---------|---------------|
+| `test_function_name` | [what it verifies] | `tests/test_module.py` |
+
+### Integration/E2E Coverage
+
+- [IT-XX — now runnable (this story implements the relevant boundary)]
+- [E2E-XX — partially runnable (needs #NNN for completion)]
+
+## Acceptance Criteria
+
+- [ ] [Testable condition — names exact files, functions, commands, or behaviors]
+- [ ] [Testable condition]
+- [ ] [Testable condition]
+
+## Dependencies
+
+- #NNN — [description of dependency]
+- None (if no dependencies)
+```
+
+#### Bug
+
+```markdown
+## Summary
+
+[Concise description of the defect]
+
+## Environment
+
+- **Where observed:** [page, component, CLI command, API endpoint]
+- **Version/commit:** [git SHA or release tag where defect exists]
+- **Frequency:** intermittent | consistent
+
+## Steps to Reproduce
+
+1. [Step one]
+2. [Step two]
+3. [Step three]
+
+## Expected Behavior
+
+[What should happen]
+
+## Actual Behavior
+
+[What actually happens]
+
+## Severity
+
+[`severity::critical` | `severity::major` | `severity::minor` | `severity::cosmetic`]
+
+## Artifacts
+
+- [Links to logs, screenshots, error traces, or other evidence]
+
+## Workaround
+
+[Describe workaround if known, or "None known"]
+```
+
+#### Docs
+
+```markdown
+## Summary
+
+[Which document(s) to create or update, and why]
+
+## Target Audience
+
+[Who will read this — developers, operators, end users, agents]
+
+## What's Missing, Outdated, or Incorrect
+
+[Specific gaps or inaccuracies in current documentation]
+
+## Source Material
+
+- [Pointers to code, PRDs, conversations, or other references]
+
+## Acceptance Criteria
+
+- [ ] Content is accurate against current codebase
+- [ ] Coverage is complete for the stated scope
+- [ ] No broken links
+- [ ] [Additional testable conditions]
+```
+
+#### Chore
+
+```markdown
+## Summary
+
+[Description of the maintenance task and its rationale]
+
+## Implementation Steps
+
+[Mandatory if the chore touches >1 file or has ordering constraints.
+Optional for trivial single-file changes.]
+
+1. [Step]
+2. [Step]
+
+## Acceptance Criteria
+
+- [ ] [Testable condition — always mandatory for chores]
+- [ ] [Testable condition]
+```
+
+#### Epic
+
+Structure lifted from `docs/PRD-template.md` Phase format.
+
+```markdown
+## Goal
+
+[One sentence: what this epic proves or delivers]
+
+## Scope
+
+**In scope:**
+- [What is included]
+
+**Out of scope:**
+- [What is explicitly excluded and why]
+
+## Definition of Done
+
+- [ ] [Verifiable condition — concrete and testable, not vague]
+- [ ] [Verifiable condition]
+- [ ] All sub-issue AC checklists are satisfied
+
+## Sub-Issues
+
+[Listed with dependency order]
+
+| Order | Issue | Title | Dependencies |
+|-------|-------|-------|-------------|
+| 1 | #NNN | [title] | None |
+| 2 | #NNN | [title] | #NNN |
+| 3 | #NNN | [title] | #NNN, #NNN |
+
+## Wave Map
+
+[If applicable — which sub-issues can run in parallel]
+
+| Wave | Issues | Parallel? |
+|------|--------|-----------|
+| 1 | #NNN | Single |
+| 2 | #NNN, #NNN | Yes |
+
+## Success Metrics
+
+[If applicable — quantitative or qualitative measures of success]
+```
+
+### Quality Standard
+
+Every issue — regardless of type — must be written to **wave-pattern quality**: detailed enough that a spec-driven agent can pick it up and execute without making design decisions. Implementation steps should read like paint-by-numbers. Acceptance criteria should be evaluable before PR/MR merge. If an issue requires the implementer to make architectural or design choices, it is underspecified.
+
+---
+
+## Branching Strategy
+
+**Trunk-Based Flow with Main Branch**
+
+```
+main (protected)
+  ├── feature/XXX-description
+  ├── fix/XXX-description
+  ├── chore/XXX-description
+  └── docs/XXX-description
+```
+
+**Always branch from `main`**:
+
+```bash
+git checkout main
+git pull
+git checkout -b feature/XXX-description
+```
+
+PR/MRs target `main`.
+
+### Branch Naming
+
+```
+<type>/<brief-description>
+
+Examples:
+  feature/credential-management
+  fix/ldap-connection-timeout
+  chore/update-dependencies
+  docs/add-api-reference
+```
+
+Types: `feature`, `fix`, `chore`, `docs`
+
+---
+
+## Code Standards
+
+**Discover the project's tooling rather than assuming a specific stack.**
+
+On session start (or before first lint/format/test), detect what's available:
+
+1. **Check for a `Makefile`** — If it has `lint`, `format`, `typecheck`, or `test` targets, prefer those. They wrap the project's chosen tools.
+2. **Check for config files** — `pyproject.toml` (Python/ruff/mypy), `package.json` (Node), `Cargo.toml` (Rust), `go.mod` (Go), `.clang-format` (C/C++), etc.
+3. **Check for CI scripts** — `scripts/ci/` often reveals what the project expects to pass.
+
+Use whatever the project provides. Do not introduce new formatters or linters that the project doesn't already use.
+
+### Common Defaults (when no project-specific config is found)
+
+| Language | Formatter | Linter | Tests |
+|----------|-----------|--------|-------|
+| Python | ruff format | ruff check | pytest |
+| Shell | shfmt | shellcheck | - |
+| JavaScript/TypeScript | prettier | eslint | jest/vitest |
+| Go | gofmt | go vet | go test |
+| Rust | rustfmt | clippy | cargo test |
+
+---
+
+## CRITICAL: No Procedural Logic in CI/CD YAML
+
+**If you are about to add more than 5 lines to any `run:` or `script:` section in CI/CD configuration (GitHub Actions workflows or `.gitlab-ci.yml`), STOP IMMEDIATELY.**
+
+Create a shell script in `scripts/ci/` instead. This is a HARD RULE, not a guideline.
+
+```yaml
+# CORRECT
+build:
+  steps:
+    - run: ./scripts/ci/build.sh
+
+# WRONG
+build:
+  steps:
+    - run: |
+        echo "Building..."
+        cd src && pip install .
+        export VAR=$(ls dist/*.whl)
+        # ... more procedural lines
+```
+
+---
+
+## Secrets and Sensitive Files
+
+**Before staging any file that may contain secrets, WARN the user and get explicit confirmation.**
+
+Watch for these patterns when adding files to a commit:
+- `.env`, `.env.*`, `*.secret`, `*.key`, `*.pem`, `*.p12`, `*.pfx`
+- `credentials.json`, `service-account*.json`, `*-credentials.*`
+- Files containing API keys, tokens, passwords, or connection strings
+- `terraform.tfvars`, `*.auto.tfvars` (may contain infrastructure secrets)
+
+**When a suspect file is about to be staged:**
+1. Flag it explicitly: *"This file looks like it may contain secrets: `<filename>`. Are you sure you want to include it?"*
+2. Wait for explicit confirmation before staging
+3. If confirmed, proceed — some projects legitimately require committing these files
+
+This is a **safety net, not a hard block**. Trust the user's judgment after warning.
+
+---
+
+## Commit Message Format
 
 ```
 type(scope): brief description
 
-Closes #NNN
+[Optional body]
+
+Closes #XXX
 ```
 
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
-## Mandatory Rules
+---
 
-1. **Always have an issue** — never begin work without one
-2. **Test before push** — run `bun test` and `bun run lint`
-3. **Pre-commit gate** — run `/precheck` before committing
+## PR/MR Description Format
+
+When creating a PR/MR, use this structure:
+
+```markdown
+## Summary
+
+[1-3 sentences: what changed and why]
+
+## Changes
+
+- [Bulleted list of notable changes, grouped logically]
+
+## Linked Issues
+
+Closes #NNN
+
+## Test Plan
+
+- [How was this tested? What commands were run?]
+- [Any manual verification steps?]
+```
+
+**Rules:**
+- The title should be concise (under 72 characters), following the same `type(scope): description` convention as commits
+- Always link issues using `Closes #NNN` (GitHub) or `Closes #NNN` (GitLab) so they auto-close on merge
+- The test plan must reflect what was *actually done*, not what *could be done*
+
+---
+
+## Session Onboarding
+
+When starting a session:
+1. **Detect platform** — Read `.claude-project.md` if it exists; otherwise run `git remote -v` and determine GitHub vs GitLab (see Platform Detection)
+2. **Resolve identity** — Check Dev-Team, pick session Dev-Name/Dev-Avatar (see Agent Identity)
+3. **Load context** — Check for and read `Docs/implementation-plan.md` (or similar planning documents) for current state and context. If no such file exists, proceed without it.
+
+### Discord Watcher (Channels)
+
+If the session was started with `--channels` (or `--dangerously-load-development-channels`), a Discord watcher channel server pushes notifications when new messages arrive in any Oak and Wave text channel.
+
+**When you receive a `<channel source="discord_watcher">` notification:**
+
+1. Run `discord-bot read <channel_id> --limit 10` to get the full messages
+2. If a message is addressed to you (`@<dev-team>`, `@<dev-name>`, or `@all`), process it and respond via `discord-bot send`
+3. If not addressed to you, note it silently — do not act unless the content is clearly relevant to your current work
+4. Ignore messages that contain your own signature (e.g., `— **beacon**`) to avoid echo loops — other agents' messages (also from `CC Developer`) should be processed normally
+
+**Discord message format — sign every message:**
+
+```
+Your message content here.
+
+— **<Dev-Name>** <Dev-Avatar> (<Dev-Team>)
+```
+
+Example: `— **beacon** :satellite: (cc-workflow)`
+
+The signature is used by the watcher to filter your own echoes. Messages without your signature will echo back to you.
+
+**Message addressing convention:**
+
+| Pattern | Meaning |
+|---------|---------|
+| `@<dev-team>` (e.g., `@cc-workflow`) | Addressed to a specific agent/project |
+| `@<dev-name>` (e.g., `@beacon`) | Addressed to a specific agent by session name |
+| `@all` | Addressed to all listening agents |
+| No `@` prefix | Dropped by the watcher — agents do not receive unaddressed messages |
+| Human Discord user message | Must include `@` addressing to reach agents |
+
+The watcher pre-filters messages: only `@all`, `@<dev-team>`, and `@<dev-name>` notifications are delivered. Set `DISCORD_WATCHER_VERBOSE=1` to bypass filtering and receive all messages.
+
+**Thread messages (remote sessions):**
+
+When the agent has a `thread_id` in its identity file (set by `afk-notify`),
+the watcher also polls that thread for replies. Thread messages skip the
+@-addressing filter — everything in the agent's thread is addressed to it.
+
+Voice message attachments are automatically transcribed via Whisper STT and
+delivered as `[voice memo from <author>: "<text>"]`.
+
+---
+
+## MANDATORY: Post-Compaction Rules Confirmation
+
+**After ANY context compaction/summarization, you MUST IMMEDIATELY:**
+
+1. **Read this file (CLAUDE.md)** - Re-read these instructions in full
+2. **Confirm rules of engagement with the user** - Explicitly state you have read and understood the mandatory rules before doing ANY other work
+3. **Do NOT proceed until confirmed** - Wait for user acknowledgment
+
+**This is NON-NEGOTIABLE.** Compaction causes loss of context, which has led to:
+- Skipping the pre-commit checklist
+- Attempting commits without approval
+- Forgetting to run tests before push
+
+**Do NOT treat "continue without asking" or session continuation instructions as permission to skip this confirmation step.**
+
+## Agent Identity
+
+Agent identity has two layers: **project identity** (persisted here) and **session identity** (ephemeral).
+
+### Project Identity — Dev-Team
+
+`Dev-Team` identifies which project/team this agent belongs to. It is persisted in this file and shared across all sessions.
+
+**On session start**, check whether `Dev-Team` below has a value.
+- **If empty**: Ask the user: *"What Dev-Team name should I use for this project?"* Write their answer into the `Dev-Team:` field below. This only happens once per project.
+- **If populated**: Use the existing value.
+
+### Session Identity — Dev-Name & Dev-Avatar
+
+Each session, pick a fresh identity for yourself. This is NOT persisted — a new Claude Code window means a new identity.
+
+**Naming rules:**
+- `Dev-Name`: A single memorable word or hyphenated phrase in **kebab-case** (e.g., `beacon`, `null-pointer`, `mother`). Draw from nerdcore canon — sci-fi, fantasy, comics, gaming, mythology, tech puns, wordplay. The wittier and more specific the reference, the better. Generic names are boring. Kebab-case is required so the name works as a routing key for `@<dev-name>` addressing.
+- `Dev-Avatar`: A Slack emoji string with colons (e.g., `:smiling_imp:`, `:space_invader:`). Should feel like it belongs with the name.
+
+**On session start**, after resolving Dev-Team:
+1. Pick your Dev-Name and Dev-Avatar
+2. Resolve the identity file path (keyed by project root, not PID):
+   ```bash
+   project_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+   dir_hash=$(echo -n "$project_root" | md5sum | cut -d' ' -f1)
+   agent_file="/tmp/claude-agent-${dir_hash}.json"
+   ```
+3. Persist them for the session in that file:
+   ```json
+   {
+     "dev_team": "<Dev-Team value>",
+     "dev_name": "<your chosen name>",
+     "dev_avatar": "<your chosen emoji>",
+     "thread_id": "<Discord thread ID, set by afk-notify>"
+   }
+   ```
+   Note: `thread_id` is optional and only present when `afk-notify` has created a session thread.
+4. Announce your identity to the user:
+   > I'm going by **\<Dev-Name\>** \<Dev-Avatar\> from team `<Dev-Team>` this session.
+5. **Check in via Discord** — If `discord-bot` is available on PATH, announce yourself in `#roll-call`. Read the channel ID from config:
+   ```bash
+   ROLL_CALL=$(jq -r '.channels["roll-call"].id' ~/.claude/discord.json 2>/dev/null || echo "1487382005036617851")
+   discord-bot send "$ROLL_CALL" "<message>"
+   ```
+   Message format:
+   ```
+   **<dev-name>** <dev-avatar> online — team `<dev-team>` @ <project-root>
+
+   — **<dev-name>** <dev-avatar> (<dev-team>)
+   ```
+   If `discord-bot` is not available or the send fails, skip silently — check-in is best-effort, not a blocker.
+
+### Reading Identity
+
+Identity files are keyed by md5 hash of the project root directory, so the statusline and all skills resolve the same file regardless of process ancestry.
+
+Any skill or behavior that needs agent identity should:
+1. Read `Dev-Team` from this file
+2. Resolve the identity file: `md5sum` of `git rev-parse --show-toplevel`
+3. Read `Dev-Name` and `Dev-Avatar` from `/tmp/claude-agent-<dir_hash>.json`
 
 Dev-Team: mcp-server-wtf

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ classifier into a distilled timeline.
 curl -fsSL https://raw.githubusercontent.com/Wave-Engineering/mcp-server-wtf/main/scripts/install-remote.sh | bash
 ```
 
-This downloads a pre-compiled binary for your platform, installs skills and the
+This downloads a pre-compiled binary for your platform, installs the
 PostToolUse hook, and registers the MCP server. No clone or runtime required.
+Skills (`/wtf`, `/wtf now`, `/wtf happened`, `/wtf imout`) are delivered by
+[claudecode-workflow](https://github.com/Wave-Engineering/claudecode-workflow).
 
 Verify the installation:
 
@@ -221,7 +223,7 @@ If installed from a local clone:
 ./scripts/install.sh --uninstall
 ```
 
-Both remove the MCP server registration, skills, and hook configuration. The
+Both remove the MCP server registration and hook configuration. The
 per-project `.wtf/` data directories are preserved (they contain incident
 history). To remove them:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,7 @@ WTF (Why That Failed) is a flight recorder for incident troubleshooting sessions
 +-----------------------------------------------------------------+
 ```
 
-**Layer 1 -- Skills:** `/wtf` and `/wtf now` are user-facing skill definitions (Markdown files in `skills/`) that invoke MCP tools and inject behavioral instructions.
+**Layer 1 -- Skills:** `/wtf` and `/wtf now` are user-facing skill definitions that invoke MCP tools and inject behavioral instructions. Skills are delivered by [claudecode-workflow](https://github.com/Wave-Engineering/claudecode-workflow), not this repo.
 
 **Layer 2 -- PostToolUse Hook:** A shell script (`scripts/hooks/wtf-post-tool-use.sh`) that fires on every Claude Code tool call, extracts fields from the hook payload, truncates large values, and appends a JSON line to `.wtf/hook-queue.jsonl`.
 
@@ -571,12 +571,6 @@ scripts/
     test.sh                        # bun install --frozen-lockfile + bun test
   hooks/
     wtf-post-tool-use.sh           # PostToolUse hook (captures tool calls to JSONL queue)
-
-skills/                            # Skill definitions (Markdown files)
-  wtf/
-    SKILL.md                       # /wtf skill -- starts flight recorder mode
-  wtf-now/
-    SKILL.md                       # /wtf now skill -- adds manual journal entries
 
 docs/
   PRD-wtf-server.md                # Product requirements document

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -14,12 +14,9 @@ mkdir -p release-assets
 find artifacts -type f -name 'wtf-server-*' -exec cp {} release-assets/ \;
 find release-assets -type f -name 'wtf-server-*' -exec chmod +x {} \;
 
-# Copy skills and hook into release assets.
+# Copy hook and installer into release assets.
 cp scripts/hooks/wtf-post-tool-use.sh release-assets/
 cp scripts/install-remote.sh release-assets/
-for skill in wtf wtf-now wtf-happened wtf-imout; do
-    cp "skills/${skill}/SKILL.md" "release-assets/${skill}-SKILL.md"
-done
 
 # Create the release (or upload to an existing one).
 if gh release view "$TAG" &>/dev/null; then

--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -16,7 +16,6 @@ BASE_URL="https://github.com/${REPO}/releases"
 
 INSTALL_DIR="${WTF_INSTALL_DIR:-$HOME/.local/bin}"
 DATA_DIR="$HOME/.local/share/wtf-server"
-SKILLS_DIR="$HOME/.claude/skills"
 SETTINGS_FILE="$HOME/.claude/settings.json"
 HOOK_PATH="$DATA_DIR/hooks/wtf-post-tool-use.sh"
 
@@ -146,15 +145,6 @@ do_install() {
     ok "Hook installed to $HOOK_PATH"
     echo ""
 
-    # Download skills
-    info "Installing skills..."
-    for skill in wtf wtf-now wtf-happened wtf-imout; do
-        mkdir -p "$SKILLS_DIR/$skill"
-        fetch "$(resolve_url "${skill}-SKILL.md")" "$SKILLS_DIR/$skill/SKILL.md"
-        ok "Installed /$skill"
-    done
-    echo ""
-
     # Register MCP server (remove first for idempotency)
     info "Registering MCP server: $MCP_SERVER_NAME"
     claude mcp remove "$MCP_SERVER_NAME" 2>/dev/null || true
@@ -177,7 +167,6 @@ do_install() {
     echo "Installation Summary"
     echo "--------------------"
     ok "Binary: ${INSTALL_DIR}/wtf-server"
-    ok "Skills: ${SKILLS_DIR}/wtf/, wtf-now/, wtf-happened/, wtf-imout/"
     ok "Hook: PostToolUse → $HOOK_PATH"
     ok "Data dir: .wtf/ (created on first use, per project)"
     echo ""
@@ -242,18 +231,6 @@ do_uninstall() {
     else
         warn "MCP server was not registered"
     fi
-
-    # Remove skills
-    info "Removing skills..."
-    for skill in wtf wtf-now wtf-happened wtf-imout; do
-        if [[ -f "$SKILLS_DIR/$skill/SKILL.md" ]]; then
-            rm "$SKILLS_DIR/$skill/SKILL.md"
-            rmdir "$SKILLS_DIR/$skill" 2>/dev/null || true
-            ok "Removed /$skill"
-        else
-            warn "Skill /$skill not found"
-        fi
-    done
 
     # Remove hook from settings
     info "Removing PostToolUse hook..."
@@ -325,16 +302,6 @@ do_check() {
         fail "MCP server not registered"
         issues=$((issues + 1))
     fi
-
-    # Skills
-    for skill in wtf wtf-now wtf-happened wtf-imout; do
-        if [[ -f "$SKILLS_DIR/$skill/SKILL.md" ]]; then
-            ok "Skill /$skill installed"
-        else
-            fail "Skill /$skill missing"
-            issues=$((issues + 1))
-        fi
-    done
 
     # Hook
     if [[ -f "$SETTINGS_FILE" ]] && \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 MCP_DIR="$PROJECT_DIR"
 HOOK_PATH="$PROJECT_DIR/scripts/hooks/wtf-post-tool-use.sh"
-SKILLS_DIR="$HOME/.claude/skills"
 SETTINGS_FILE="$HOME/.claude/settings.json"
 
 MCP_SERVER_NAME="wtf-server"
@@ -75,16 +74,6 @@ register_mcp() {
     ok "MCP server registered (scope: user)"
 }
 
-install_skills() {
-    info "Installing skills to $SKILLS_DIR"
-    mkdir -p "$SKILLS_DIR/wtf" "$SKILLS_DIR/wtf-now" "$SKILLS_DIR/wtf-happened" "$SKILLS_DIR/wtf-imout"
-    cp "$PROJECT_DIR/skills/wtf/SKILL.md" "$SKILLS_DIR/wtf/SKILL.md"
-    cp "$PROJECT_DIR/skills/wtf-now/SKILL.md" "$SKILLS_DIR/wtf-now/SKILL.md"
-    cp "$PROJECT_DIR/skills/wtf-happened/SKILL.md" "$SKILLS_DIR/wtf-happened/SKILL.md"
-    cp "$PROJECT_DIR/skills/wtf-imout/SKILL.md" "$SKILLS_DIR/wtf-imout/SKILL.md"
-    ok "Installed /wtf, /wtf now, /wtf happened, and /wtf imout skills"
-}
-
 configure_hook() {
     info "Configuring PostToolUse hook in $SETTINGS_FILE"
 
@@ -133,16 +122,12 @@ do_install() {
     register_mcp
     echo ""
 
-    install_skills
-    echo ""
-
     configure_hook
     echo ""
 
     echo "Installation Summary"
     echo "--------------------"
     ok "MCP server: $MCP_SERVER_NAME (bun $MCP_DIR/index.ts)"
-    ok "Skills: ~/.claude/skills/wtf/, ~/.claude/skills/wtf-now/, ~/.claude/skills/wtf-happened/"
     ok "Hook: PostToolUse → $HOOK_PATH"
     ok "Data dir: .wtf/ (created on first use)"
     echo ""
@@ -180,16 +165,6 @@ do_check() {
         fail "MCP server '$MCP_SERVER_NAME' not registered"
         issues=$((issues + 1))
     fi
-
-    # Skills
-    for skill in wtf wtf-now wtf-happened wtf-imout; do
-        if [[ -f "$SKILLS_DIR/$skill/SKILL.md" ]]; then
-            ok "Skill /$skill installed"
-        else
-            fail "Skill /$skill not found at $SKILLS_DIR/$skill/SKILL.md"
-            issues=$((issues + 1))
-        fi
-    done
 
     # Hook
     if [[ -f "$SETTINGS_FILE" ]] && \
@@ -236,18 +211,6 @@ do_uninstall() {
     else
         warn "MCP server '$MCP_SERVER_NAME' was not registered"
     fi
-
-    # Remove skills
-    info "Removing skills..."
-    for skill in wtf wtf-now wtf-happened wtf-imout; do
-        if [[ -f "$SKILLS_DIR/$skill/SKILL.md" ]]; then
-            rm "$SKILLS_DIR/$skill/SKILL.md"
-            rmdir "$SKILLS_DIR/$skill" 2>/dev/null || true
-            ok "Removed skill /$skill"
-        else
-            warn "Skill /$skill was not installed"
-        fi
-    done
 
     # Remove hook from settings
     info "Removing PostToolUse hook from settings..."


### PR DESCRIPTION
Skills now live in claudecode-workflow. Removes skill install/check/uninstall from both installers and release script. Updates docs.